### PR TITLE
Invite to battle

### DIFF
--- a/backend/battles/forms.py
+++ b/backend/battles/forms.py
@@ -3,13 +3,7 @@ from django import forms
 from dal import autocomplete
 
 from battles.choices import POKEMON_ORDER_CHOICES
-from battles.helpers.common import (
-    change_battle_status,
-    duplicate_in_set,
-    pokemon_team_exceeds_limit,
-)
-from battles.helpers.email import send_result_email
-from battles.helpers.fight import run_battle
+from battles.helpers.common import duplicate_in_set, pokemon_team_exceeds_limit
 from battles.models import Battle, Team
 from pokemon.models import Pokemon
 from users.models import User
@@ -83,16 +77,6 @@ class CreateTeamForm(forms.ModelForm):
             second_pokemon=battle_order["2"],
             third_pokemon=battle_order["3"],
         )
-
-        # Runs battle
-
-        battle = Battle.objects.get(pk=self.initial["battle"].pk)
-        creator = battle.user_creator
-        opponent = battle.user_opponent
-        if trainer == opponent:
-            result = run_battle(creator.teams.get(battle=battle.pk), instance)
-            change_battle_status(battle, result["winner"].trainer)
-            send_result_email(result)
         return instance
 
     def clean(self):

--- a/backend/battles/helpers/email.py
+++ b/backend/battles/helpers/email.py
@@ -1,6 +1,11 @@
+import logging
+
 from django.conf import settings
 
 from templated_email import send_templated_mail
+
+
+logger = logging.getLogger(__name__)
 
 
 def send_result_email(result):
@@ -26,3 +31,4 @@ def send_invite_to_match(invitee, invited):
         recipient_list=[invited],
         context={"invitee": invitee, "invited": invited},
     )
+    logger.info("Sent email invite to battle")

--- a/backend/battles/helpers/email.py
+++ b/backend/battles/helpers/email.py
@@ -17,3 +17,12 @@ def send_result_email(result):
             "loser_team": (loser.first_pokemon, loser.second_pokemon, loser.third_pokemon),
         },
     )
+
+
+def send_invite_to_match(invitee, invited):
+    send_templated_mail(
+        template_name="invite_to_battle",
+        from_email=settings.SERVER_EMAIL,
+        recipient_list=[invited],
+        context={"invitee": invitee, "invited": invited},
+    )

--- a/backend/battles/helpers/email.py
+++ b/backend/battles/helpers/email.py
@@ -8,7 +8,7 @@ from templated_email import send_templated_mail
 logger = logging.getLogger(__name__)
 
 
-def send_result_email(result):
+def send_result_email(result, url):
     winner = result["winner"]
     loser = result["loser"]
     send_templated_mail(
@@ -20,15 +20,17 @@ def send_result_email(result):
             "winner_team": (winner.first_pokemon, winner.second_pokemon, winner.third_pokemon),
             "loser": loser.trainer,
             "loser_team": (loser.first_pokemon, loser.second_pokemon, loser.third_pokemon),
+            "url": url,
         },
     )
+    logger.info("Sent email with battle results")
 
 
-def send_invite_to_match(invitee, invited):
+def send_invite_to_match(invitee, invited, url):
     send_templated_mail(
         template_name="invite_to_battle",
         from_email=settings.SERVER_EMAIL,
         recipient_list=[invited],
-        context={"invitee": invitee, "invited": invited},
+        context={"invitee": invitee, "invited": invited, "url": url},
     )
     logger.info("Sent email invite to battle")

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -212,8 +212,12 @@ class TestCreateTeamView(TestCase):
         self.assertTrue(response.context["user_has_team"])
 
     def test_invite_email_is_sent(self):
+        battle = mommy.make(
+            "battles.Battle", user_creator=self.creator, user_opponent=self.opponent
+        )
         post_data = {
             "trainer": self.creator.id,
+            "battle": battle.id,
             "pokemon_1": mommy.make("pokemon.Pokemon", name="ivysaur").id,
             "pokemon_2": mommy.make("pokemon.Pokemon", name="bulbasaur").id,
             "pokemon_3": mommy.make("pokemon.Pokemon", name="pikachu").id,

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -1,3 +1,4 @@
+from django.core import mail
 from django.test import Client, TestCase
 from django.urls import reverse
 
@@ -50,6 +51,14 @@ class TestCreateBattleView(TestCase):
         response = self.client.get(self.view_url)
         options = response.context["form"].fields["user_opponent"].queryset
         self.assertNotIn(self.client, options)
+
+    def test_invite_email_is_sent(self):
+        post_data = {"user_creator": self.creator.id, "user_opponent": self.opponent.id}
+        self.client.post(self.view_url, post_data)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(
+            mail.outbox[0].subject, f"PokeBattle - {self.creator.email} invited you to a match"
+        )
 
 
 class TestDetailBattleView(TestCase):

--- a/backend/battles/views.py
+++ b/backend/battles/views.py
@@ -57,11 +57,13 @@ class CreateTeamView(LoginRequiredMixin, UserNotInvitedToBattleMixin, CreateView
         opponent = battle.user_opponent
 
         if self.object.trainer == battle.user_creator:
-            send_invite_to_match(creator, opponent)
+            send_invite_to_match(
+                creator, opponent, self.request.build_absolute_uri(f"/create-team/{battle.id}")
+            )
         if self.object.trainer == battle.user_opponent:
             result = run_battle(creator.teams.get(battle=battle.pk), self.object)
             change_battle_status(battle, result["winner"].trainer)
-            send_result_email(result)
+            send_result_email(result, self.request.build_absolute_uri("/"))
 
         return HttpResponseRedirect(self.get_success_url())
 

--- a/backend/battles/views.py
+++ b/backend/battles/views.py
@@ -5,6 +5,7 @@ from django.views.generic import CreateView, DetailView, ListView
 
 from battles.forms import CreateBattleForm, CreateTeamForm
 from battles.helpers.common import get_battle_opponent, get_respective_teams_in_battle
+from battles.helpers.email import send_invite_to_match
 from battles.mixins import UserIsNotInThisBattleMixin, UserNotInvitedToBattleMixin
 from battles.models import Battle
 from users.models import User
@@ -20,6 +21,11 @@ class CreateBattleView(LoginRequiredMixin, CreateView):
 
     def get_success_url(self):
         return reverse_lazy("battles:create_team", args=[self.object.id])
+
+    def form_valid(self, form):
+        self.object = form.save()
+        send_invite_to_match(self.object.user_creator.email, self.object.user_opponent.email)
+        return super().form_valid(form)
 
 
 class CreateTeamView(LoginRequiredMixin, UserNotInvitedToBattleMixin, CreateView):

--- a/backend/battles/views.py
+++ b/backend/battles/views.py
@@ -1,11 +1,17 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Q
+from django.http import HttpResponseRedirect
 from django.urls import reverse_lazy
 from django.views.generic import CreateView, DetailView, ListView
 
 from battles.forms import CreateBattleForm, CreateTeamForm
-from battles.helpers.common import get_battle_opponent, get_respective_teams_in_battle
-from battles.helpers.email import send_invite_to_match
+from battles.helpers.common import (
+    change_battle_status,
+    get_battle_opponent,
+    get_respective_teams_in_battle,
+)
+from battles.helpers.email import send_invite_to_match, send_result_email
+from battles.helpers.fight import run_battle
 from battles.mixins import UserIsNotInThisBattleMixin, UserNotInvitedToBattleMixin
 from battles.models import Battle
 from users.models import User
@@ -21,11 +27,6 @@ class CreateBattleView(LoginRequiredMixin, CreateView):
 
     def get_success_url(self):
         return reverse_lazy("battles:create_team", args=[self.object.id])
-
-    def form_valid(self, form):
-        self.object = form.save()
-        send_invite_to_match(self.object.user_creator.email, self.object.user_opponent.email)
-        return super().form_valid(form)
 
 
 class CreateTeamView(LoginRequiredMixin, UserNotInvitedToBattleMixin, CreateView):
@@ -48,6 +49,21 @@ class CreateTeamView(LoginRequiredMixin, UserNotInvitedToBattleMixin, CreateView
             context["user_has_team"] = True
 
         return context
+
+    def form_valid(self, form):
+        self.object = form.save()
+        battle = self.object.battle
+        creator = battle.user_creator
+        opponent = battle.user_opponent
+
+        if self.object.trainer == battle.user_creator:
+            send_invite_to_match(creator, opponent)
+        if self.object.trainer == battle.user_opponent:
+            result = run_battle(creator.teams.get(battle=battle.pk), self.object)
+            change_battle_status(battle, result["winner"].trainer)
+            send_result_email(result)
+
+        return HttpResponseRedirect(self.get_success_url())
 
 
 class ListSettledBattlesView(LoginRequiredMixin, ListView):

--- a/backend/battles/views.py
+++ b/backend/battles/views.py
@@ -58,7 +58,9 @@ class CreateTeamView(LoginRequiredMixin, UserNotInvitedToBattleMixin, CreateView
 
         if self.object.trainer == battle.user_creator:
             send_invite_to_match(
-                creator, opponent, self.request.build_absolute_uri(f"/create-team/{battle.id}")
+                creator.email,
+                opponent.email,
+                self.request.build_absolute_uri(f"/create-team/{battle.id}"),
             )
         if self.object.trainer == battle.user_opponent:
             result = run_battle(creator.teams.get(battle=battle.pk), self.object)

--- a/backend/templates/templated_email/invite_to_battle.email
+++ b/backend/templates/templated_email/invite_to_battle.email
@@ -1,10 +1,10 @@
 {% block subject %}PokeBattle - {{invitee}} invited you to a match{% endblock %}
 
 {% block plain %}
-    Hi {{ invited }}, {{ invitee }} invited you to a match. Checkout at https://pantoja-pokebattle.herokuapp.com/ to play with them!
+    Hi {{ invited }}, {{ invitee }} invited you to a match. Checkout at {{ url }} to play with them!
 {% endblock %}
 
 {% block html %}
     <p>Hi {{ invited }},</p>
-    <p>{{ invitee }} invited you to a match. Checkout at <a href="https://pantoja-pokebattle.herokuapp.com/">Pokebattle</a> to play with them!</p>
+    <p>{{ invitee }} invited you to a match. Checkout at <a href="{{ url }}">Pokebattle</a> to play with them!</p>
 {% endblock %}

--- a/backend/templates/templated_email/invite_to_battle.email
+++ b/backend/templates/templated_email/invite_to_battle.email
@@ -1,0 +1,10 @@
+{% block subject %}PokeBattle - Here's the result of your battle{% endblock %}
+
+{% block plain %}
+    Hi {{ invited }}, {{ invitee }} invited you to a match. Checkout at https://pantoja-pokebattle.herokuapp.com/ to play with them!
+{% endblock %}
+
+{% block html %}
+    <p>Hi {{ invited }},</p>
+    <p>{{ invitee }} invited you to a match. Checkout at <a href="https://pantoja-pokebattle.herokuapp.com/">Pokebattle</a> to play with them!</p>
+{% endblock %}

--- a/backend/templates/templated_email/invite_to_battle.email
+++ b/backend/templates/templated_email/invite_to_battle.email
@@ -1,4 +1,4 @@
-{% block subject %}PokeBattle - Here's the result of your battle{% endblock %}
+{% block subject %}PokeBattle - {{invitee}} invited you to a match{% endblock %}
 
 {% block plain %}
     Hi {{ invited }}, {{ invitee }} invited you to a match. Checkout at https://pantoja-pokebattle.herokuapp.com/ to play with them!

--- a/backend/templates/templated_email/send_result.email
+++ b/backend/templates/templated_email/send_result.email
@@ -17,7 +17,7 @@
 
     ATT: {{ winner_team.2.attack }} DEF: {{ winner_team.2.defense }} HP: {{ winner_team.2.hp }} --> {{ winner_team.2|capfirst }} VS {{ loser_team.2|capfirst }} <-- ATT: {{ loser_team.2.attack }} DEF: {{ loser_team.2.defense }} HP: {{ loser_team.2.hp }}
 
-Congratulations {{ winner }}, you won! Play another round at pantoja-pokebattle.herokuapp.com
+Congratulations {{ winner }}, you won! Play another round at {{ url }}
 
 {% endblock %}
 
@@ -116,7 +116,7 @@ Congratulations {{ winner }}, you won! Play another round at pantoja-pokebattle.
   </table>
 
   <p> Congratulations, {{ winner.get_short_name }} is the winner of this battle.
-    Play another round at <a href="pantoja-pokebattle.herokuapp.com">PokeBattle</a>
+    Play another round at <a href="{{ url }}">PokeBattle</a>
   </p>
 
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Created a function to send an email to the opponent containing a battle invitation
- Refactored the change battle status code (moved from forms to views).
- Added tests for sent email and change battle status functions. 

## Trello Card
<!--- Why is this change required? What problem does it solve? -->
As a selected opponent I receive an email when I'm invited to a match
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/38823219/78705549-0598d480-78e4-11ea-9d2e-f966c2478631.png)

## Steps to reproduce (if appropriate):
URL: https://staging-pantoja-pokebattle.herokuapp.com/
(using staging because heroku branches crashes with email functions)
1. Sign up with an email that you have access to to check the inbox
2. Sign out, sign in with another account or email: `admin@admin.com` password: `senhaadmin`
3. Create a battle and the opponent must be the user you signed up with in step 1
4. Proceed to create a team successfully. The email will be sent after creating a team.
5. Checkout your inbox, it should have an email with an invite to reply the battle.