### PR TITLE
Run battle asynchronously

### DIFF
--- a/backend/battles/helpers/common.py
+++ b/backend/battles/helpers/common.py
@@ -1,9 +1,5 @@
 import logging
 
-from django.core.exceptions import PermissionDenied
-
-from battles.models import Team
-
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
@@ -23,9 +19,6 @@ def duplicate_in_set(item_set):
 
 
 def change_battle_status(battle, winner):
-    if not len(Team.objects.filter(battle=battle.id)) == 2:
-        logger.error("Battle did not save both teams")
-        raise PermissionDenied
     battle.settled = True
     battle.winner = winner
     battle.save()

--- a/backend/battles/helpers/common.py
+++ b/backend/battles/helpers/common.py
@@ -3,7 +3,6 @@ import logging
 from django.core.exceptions import PermissionDenied
 
 from battles.models import Team
-from services.api import get_pokemon_stats
 
 
 logger = logging.getLogger(__name__)
@@ -12,14 +11,11 @@ logger.setLevel(logging.WARNING)
 
 def pokemon_team_exceeds_limit(team):
     limit = 600
-
-    team_stats = [get_pokemon_stats(pokemon.name) for pokemon in team]
-    sum_pokemon_stats = []
-
-    for pokemon in team_stats:
-        sum_pokemon_stats.append(sum([pokemon["attack"], pokemon["defense"], pokemon["hp"]]))
-
-    return sum(sum_pokemon_stats) > limit
+    sum_pokemon_stats = 0
+    for pokemon in team:
+        stats = sum([pokemon.attack, pokemon.defense, pokemon.hp])
+        sum_pokemon_stats += stats
+    return sum_pokemon_stats > limit
 
 
 def duplicate_in_set(item_set):

--- a/backend/battles/helpers/email.py
+++ b/backend/battles/helpers/email.py
@@ -26,7 +26,7 @@ def send_result_email(result, url):
     logger.info("Sent email with battle results")
 
 
-def send_invite_to_match(invitee, invited, url):
+def send_invite_to_battle(invitee, invited, url):
     send_templated_mail(
         template_name="invite_to_battle",
         from_email=settings.SERVER_EMAIL,

--- a/backend/battles/mixins.py
+++ b/backend/battles/mixins.py
@@ -1,3 +1,4 @@
+from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.shortcuts import redirect
 
@@ -21,4 +22,8 @@ class UserNotInvitedToBattleMixin(UserPassesTestMixin):
         return self.request.user in [battle_object.user_creator, battle_object.user_opponent]
 
     def handle_no_permission(self):
-        return redirect("home")
+        messages.info(
+            self.request,
+            "Oops. You weren't invited to this battle :( . Try challenging another friend instead",
+        )
+        return redirect("battles:create_battle")

--- a/backend/battles/tasks.py
+++ b/backend/battles/tasks.py
@@ -1,0 +1,23 @@
+from celery.utils.log import get_task_logger
+
+from battles.helpers.common import change_battle_status
+from battles.helpers.email import send_result_email
+from battles.helpers.fight import run_battle
+from battles.models import Battle, Team
+from pokebattle import celery_app
+
+
+logger = get_task_logger(__name__)
+
+
+@celery_app.task
+def run_battle_task(pk, url):
+    #  using %s because pylint raises a formatting error
+    logger.info("Running battle number %s", pk)
+    battle = Battle.objects.get(pk=pk)
+    result = run_battle(
+        Team.objects.get(battle=pk, trainer=battle.user_creator),
+        Team.objects.get(battle=pk, trainer=battle.user_opponent),
+    )
+    change_battle_status(battle, result["winner"].trainer)
+    send_result_email(result, url)

--- a/backend/battles/tasks.py
+++ b/backend/battles/tasks.py
@@ -1,7 +1,7 @@
 from celery.utils.log import get_task_logger
 
 from battles.helpers.common import change_battle_status
-from battles.helpers.email import send_result_email
+from battles.helpers.email import send_invite_to_battle, send_result_email
 from battles.helpers.fight import run_battle
 from battles.models import Battle, Team
 from pokebattle import celery_app
@@ -21,3 +21,8 @@ def run_battle_task(pk, url):
     )
     change_battle_status(battle, result["winner"].trainer)
     send_result_email(result, url)
+
+
+@celery_app.task
+def send_invite_to_battle_task(invitee, invited, url):
+    send_invite_to_battle(invitee, invited, url)

--- a/backend/battles/tasks.py
+++ b/backend/battles/tasks.py
@@ -12,7 +12,7 @@ logger = get_task_logger(__name__)
 
 @celery_app.task
 def run_battle_task(pk, url):
-    #  using %s because pylint raises a formatting error
+    #  Using %s because pylint raises a formatting error
     logger.info("Running battle number %s", pk)
     battle = Battle.objects.get(pk=pk)
     result = run_battle(

--- a/backend/battles/tests/test_tasks.py
+++ b/backend/battles/tests/test_tasks.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from model_mommy import mommy
 
 from battles.models import Battle
-from battles.tasks import run_battle_task
+from battles.tasks import run_battle_task, send_invite_to_battle_task
 
 
 class TestBattleTasks(TestCase):
@@ -28,3 +28,11 @@ class TestBattleTasks(TestCase):
         run_battle_task(self.battle.pk, self.url)
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, "PokeBattle - Here's the result of your battle")
+
+    def test_send_invite_email(self):
+        send_invite_to_battle_task(self.battle.user_creator, self.battle.user_opponent, self.url)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(
+            mail.outbox[0].subject,
+            "PokeBattle - {} invited you to a match".format(self.battle.user_creator),
+        )

--- a/backend/battles/tests/test_tasks.py
+++ b/backend/battles/tests/test_tasks.py
@@ -1,0 +1,30 @@
+from django.core import mail
+from django.test import TestCase
+
+from model_mommy import mommy
+
+from battles.models import Battle
+from battles.tasks import run_battle_task
+
+
+class TestBattleTasks(TestCase):
+    def setUp(self):
+        self.battle = mommy.make("battles.Battle")
+        self.team_1 = mommy.make(
+            "battles.Team", trainer=self.battle.user_creator, battle=self.battle
+        )
+        self.team_2 = mommy.make(
+            "battles.Team", trainer=self.battle.user_opponent, battle=self.battle
+        )
+        self.url = "test.url"
+
+    def test_change_battle_status(self):
+        run_battle_task(self.battle.pk, self.url)
+        battle = Battle.objects.get(pk=self.battle.pk)
+        self.assertTrue(battle.settled)
+        self.assertTrue(battle.winner)
+
+    def test_send_result_email(self):
+        run_battle_task(self.battle.pk, self.url)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, "PokeBattle - Here's the result of your battle")

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -193,7 +193,11 @@ class TestCreateTeamView(TestCase):
         url = reverse(self.view_name, kwargs={"pk": 2})
         response = self.client.get(url)
         self.assertRedirects(
-            response, "/", status_code=302, target_status_code=200, fetch_redirect_response=True,
+            response,
+            "/create-battle/",
+            status_code=302,
+            target_status_code=200,
+            fetch_redirect_response=True,
         )
 
     def test_user_already_has_team_in_this_battle(self):

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -224,42 +224,6 @@ class TestCreateTeamView(TestCase):
             mail.outbox[0].subject, f"PokeBattle - {self.creator.email} invited you to a match"
         )
 
-    def test_send_battle_result_email(self):
-        mommy.make("battles.Team", battle=self.battle, trainer=self.creator)
-
-        post_data = {
-            "trainer": self.opponent.id,
-            "battle": self.battle.id,
-            "pokemon_1": self.pokemon_set[0].id,
-            "pokemon_2": self.pokemon_set[1].id,
-            "pokemon_3": self.pokemon_set[2].id,
-            "order_1": "1",
-            "order_2": "2",
-            "order_3": "3",
-        }
-        self.client.post(self.view_url, post_data)
-        self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].subject, "PokeBattle - Here's the result of your battle")
-
-    def test_change_battle_status(self):
-        mommy.make("battles.Team", battle=self.battle, trainer=self.creator)
-
-        post_data = {
-            "trainer": self.opponent.id,
-            "battle": self.battle.id,
-            "pokemon_1": self.pokemon_set[0].id,
-            "pokemon_2": self.pokemon_set[1].id,
-            "pokemon_3": self.pokemon_set[2].id,
-            "order_1": "1",
-            "order_2": "2",
-            "order_3": "3",
-        }
-
-        self.client.post(self.view_url, post_data, follow=True)
-        battle = Battle.objects.get(id=self.battle.id)
-        self.assertTrue(battle.settled)
-        self.assertTrue(battle.winner)
-
 
 class TestListActiveBattles(TestCase):
     view_name = "battles:active_battles"

--- a/backend/battles/tests/test_views.py
+++ b/backend/battles/tests/test_views.py
@@ -179,6 +179,7 @@ class TestCreateTeamView(TestCase):
         self.client = Client()
         self.client.force_login(self.creator)
         self.view_url = reverse(self.view_name, kwargs={"pk": 1})
+        self.pokemon_set = mommy.make("pokemon.Pokemon", attack=50, defense=50, hp=50, _quantity=3)
 
     def test_user_allowed_to_create_team(self):
         response = self.client.get(self.view_url)
@@ -200,15 +201,19 @@ class TestCreateTeamView(TestCase):
             "battles.Team", trainer=self.creator, battle=self.battle,
         )
         response = self.client.get(self.view_url)
-        self.assertTrue(response.context["user_has_team"])
+        message = list(response.context.get("messages"))[0]
+        self.assertEqual(
+            message.message, "You've chosen your team for this battle. Check your email for results"
+        )
+        self.assertEqual(response.status_code, 200)
 
     def test_invite_email_is_sent(self):
         post_data = {
             "trainer": self.creator.id,
             "battle": self.battle.id,
-            "pokemon_1": mommy.make("pokemon.Pokemon", name="ivysaur").id,
-            "pokemon_2": mommy.make("pokemon.Pokemon", name="bulbasaur").id,
-            "pokemon_3": mommy.make("pokemon.Pokemon", name="pikachu").id,
+            "pokemon_1": self.pokemon_set[0].id,
+            "pokemon_2": self.pokemon_set[1].id,
+            "pokemon_3": self.pokemon_set[2].id,
             "order_1": "1",
             "order_2": "2",
             "order_3": "3",
@@ -225,9 +230,9 @@ class TestCreateTeamView(TestCase):
         post_data = {
             "trainer": self.opponent.id,
             "battle": self.battle.id,
-            "pokemon_1": mommy.make("pokemon.Pokemon", name="ivysaur").id,
-            "pokemon_2": mommy.make("pokemon.Pokemon", name="bulbasaur").id,
-            "pokemon_3": mommy.make("pokemon.Pokemon", name="pikachu").id,
+            "pokemon_1": self.pokemon_set[0].id,
+            "pokemon_2": self.pokemon_set[1].id,
+            "pokemon_3": self.pokemon_set[2].id,
             "order_1": "1",
             "order_2": "2",
             "order_3": "3",
@@ -242,9 +247,9 @@ class TestCreateTeamView(TestCase):
         post_data = {
             "trainer": self.opponent.id,
             "battle": self.battle.id,
-            "pokemon_1": mommy.make("pokemon.Pokemon", name="ivysaur").id,
-            "pokemon_2": mommy.make("pokemon.Pokemon", name="bulbasaur").id,
-            "pokemon_3": mommy.make("pokemon.Pokemon", name="pikachu").id,
+            "pokemon_1": self.pokemon_set[0].id,
+            "pokemon_2": self.pokemon_set[1].id,
+            "pokemon_3": self.pokemon_set[2].id,
             "order_1": "1",
             "order_2": "2",
             "order_3": "3",

--- a/backend/battles/views.py
+++ b/backend/battles/views.py
@@ -49,18 +49,18 @@ class CreateTeamView(LoginRequiredMixin, UserNotInvitedToBattleMixin, CreateView
         return context
 
     def form_valid(self, form):
-        self.object = form.save()
-        battle = self.object.battle
+        team = form.save()
+        battle = team.battle
         creator = battle.user_creator
         opponent = battle.user_opponent
 
-        if self.object.trainer == battle.user_creator:
+        if team.trainer == battle.user_creator:
             send_invite_to_battle_task(
                 creator.email,
                 opponent.email,
                 self.request.build_absolute_uri(f"/create-team/{battle.id}"),
             )
-        if self.object.trainer == battle.user_opponent:
+        if team.trainer == battle.user_opponent:
             run_battle_task.delay(battle.pk, self.request.build_absolute_uri("/"))
         return HttpResponseRedirect(self.request.path)
 

--- a/backend/battles/views.py
+++ b/backend/battles/views.py
@@ -7,10 +7,9 @@ from django.views.generic import CreateView, DetailView, ListView
 
 from battles.forms import CreateBattleForm, CreateTeamForm
 from battles.helpers.common import get_battle_opponent, get_respective_teams_in_battle
-from battles.helpers.email import send_invite_to_match
 from battles.mixins import UserIsNotInThisBattleMixin, UserNotInvitedToBattleMixin
 from battles.models import Battle
-from battles.tasks import run_battle_task
+from battles.tasks import run_battle_task, send_invite_to_battle_task
 from users.models import User
 
 
@@ -56,7 +55,7 @@ class CreateTeamView(LoginRequiredMixin, UserNotInvitedToBattleMixin, CreateView
         opponent = battle.user_opponent
 
         if self.object.trainer == battle.user_creator:
-            send_invite_to_match(
+            send_invite_to_battle_task(
                 creator.email,
                 opponent.email,
                 self.request.build_absolute_uri(f"/create-team/{battle.id}"),

--- a/backend/battles/views.py
+++ b/backend/battles/views.py
@@ -1,3 +1,4 @@
+from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db.models import Q
 from django.http import HttpResponseRedirect
@@ -46,8 +47,10 @@ class CreateTeamView(LoginRequiredMixin, UserNotInvitedToBattleMixin, CreateView
         user = User.objects.get(id=self.request.user.id)
         battle = self.kwargs["pk"]
         if user.teams.filter(battle=battle).exists():
-            context["user_has_team"] = True
-
+            messages.info(
+                self.request,
+                "You've chosen your team for this battle. Check your email for results",
+            )
         return context
 
     def form_valid(self, form):
@@ -66,8 +69,7 @@ class CreateTeamView(LoginRequiredMixin, UserNotInvitedToBattleMixin, CreateView
             result = run_battle(creator.teams.get(battle=battle.pk), self.object)
             change_battle_status(battle, result["winner"].trainer)
             send_result_email(result, self.request.build_absolute_uri("/"))
-
-        return HttpResponseRedirect(self.get_success_url())
+        return HttpResponseRedirect(self.request.path)
 
 
 class ListSettledBattlesView(LoginRequiredMixin, ListView):

--- a/backend/pokebattle/settings/local_base.py
+++ b/backend/pokebattle/settings/local_base.py
@@ -23,7 +23,7 @@ STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 AUTH_PASSWORD_VALIDATORS = []  # allow easy passwords only on local
 
 # Celery
-CELERY_TASK_ALWAYS_EAGER = False
+CELERY_TASK_ALWAYS_EAGER = True
 
 # Email
 INSTALLED_APPS += ("naomi",)

--- a/backend/templates/battles/create_battle.html
+++ b/backend/templates/battles/create_battle.html
@@ -3,8 +3,13 @@
 {% block title %}Create Battle{% endblock %}
 
 {% block body %}
+
+
 <form method="post" class="choose-opponent-form">
   {% csrf_token %}
+  {% for message in messages %}
+    <p class="create-battle-message">{{ message }}</p>
+  {% endfor %}
   {{ form.errors }}
   {{ form.non_field_errors}}
   <h2 class="choose-opponent-title">Choose your opponent:</h2>

--- a/backend/templates/battles/create_team.html
+++ b/backend/templates/battles/create_team.html
@@ -7,7 +7,7 @@
 
 {% if messages %}
   {% for message in messages %}
-    <h2 class="team-already-exists-title">{{ message }}</h2>
+    <h2 class="user-has-team-in-battle">{{ message }}</h2>
   {% endfor %}
 {% else %}
 

--- a/backend/templates/battles/create_team.html
+++ b/backend/templates/battles/create_team.html
@@ -5,8 +5,10 @@
 
 {% block body %}
 
-{% if user_has_team %}
-<h2 class="team-already-exists-title">This battle has already begun. Check your email for results</h2>
+{% if messages %}
+  {% for message in messages %}
+    <h2 class="team-already-exists-title">{{ message }}</h2>
+  {% endfor %}
 {% else %}
 
 <form method="post" class="choose-team-form">

--- a/frontend/sass/pages/create-battle.scss
+++ b/frontend/sass/pages/create-battle.scss
@@ -40,4 +40,7 @@
     top: 0;
     z-index: -1;
   }
+  .create-battle-message {
+    @include message;
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Created a celery task so that the process of **getting a battle result**, **declaring a battle winner** and **sending an email to the trainers** are running asynchronously.

Also made some improvements in the project by:
- Moving said functions (getting a battle result, declaring a battle winner and sending an email to the trainers) from forms to views.
- Removing redundant code inside functions
- Using django messages instead of a custom context to notify users.
- Using django messages inside mixin to notify why the user was redirected.
- Adding dynamic url to every email function
- Creating and cleaning up some tests

## Trello Card
<!--- Why is this change required? What problem does it solve? -->
_As the Programmer I run battles asyncronously_

## Steps to reproduce (if appropriate):
URL: https://staging-pantoja-pokebattle.herokuapp.com/
You can test if the battle is being ran by:

1. Creating a battle with another user that you have access to (it can be `admin@admin.com` password `senhaadmin`). It's preferable if you have access to the inbox of either users.
2. Login with the opponent account and answer this battle. You can do so by going to the [active battles link](https://staging-pantoja-pokebattle.herokuapp.com/active-battles/)
3. See the results by checking your email inbox and checking the [settled battle page](https://staging-pantoja-pokebattle.herokuapp.com/settled-battles/)

Also:
Test messages by clicking [here](https://staging-pantoja-pokebattle.herokuapp.com/create-team/7) (you can't answer this battle because you are not a part of it)